### PR TITLE
Simplify the installation of ANTLR dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,5 @@ matrix:
 sudo: false
 
 install:
-  - wget https://github.com/akosthekiss/antlr4/releases/download/4.5.4-SNAPSHOT%2Bpy3fixes-20160705-1111/antlr4-4.5.4-SNAPSHOT.py3fixes-20160705-1111.jar -O antlr.jar
-  - export ANTLR=$PWD/antlr.jar
   - pip install -U tox
 script: tox

--- a/README.md
+++ b/README.md
@@ -35,32 +35,37 @@ still "interesting" output.
 
 Clone the project and run setuptools:
 
-    wget -O antlr.jar https://github.com/akosthekiss/antlr4/releases/download/4.5.4-SNAPSHOT%2Bpy3fixes-20160705-1111/antlr4-4.5.4-SNAPSHOT.py3fixes-20160705-1111.jar
-    pip install -r requirements.txt
     python setup.py install
 
-Quick pip install from PyPi will be available when ANTLR 4.5.4 is officially
-released containing important fixes to the Python target and runtime.
+(Quick pip install from PyPi will be available when ANTLR 4.5.4 is officially
+released containing important fixes to the Python target and runtime.)
+
+Once the project is installed, a helper script becomes available that downloads
+the right version of the ANTLR v4 tool jar.
+
+    picireny-install-antlr4
+
 
 ## Usage
 
 *picireny* uses the same CLI as *picire* and hence accepts the same
 [options](https://github.com/renatahodovan/picire/blob/master/README.md#usage).
-On top of the inherited ones, *picireny* accepts three further arguments:
+On top of the inherited ones, *picireny* accepts several further arguments:
 
 * `--grammars` (required): List of grammars describing the input format. (You
   can write them by hand or simply download them from the [ANTLR v4 grammars
   repository](https://github.com/antlr/grammars-v4)).
 * `--start-rule` (required): Name of the rule where parsing has to start.
-* `--antlr` (required): Path the ANTLR tool jar.
+* `--antlr` (optional): Path the ANTLR tool jar.
 * `--islands` (optional): File describing how to process island grammars if
   needed.
 
 Example usage to reduce an HTML file:
 
     picireny --input=<path/to/the/input.html> --test=<path/to/the/tester> \
-             --grammars "HTMLLexer.g4 HTMLParser.g4" --start-rule document --antlr antlr.jar \
+             --grammars "HTMLLexer.g4 HTMLParser.g4" --start-rule document \
              --parallel --subset-iterator=skip --complement-iterator=backward
+
 
 ## Compatibility
 

--- a/picireny/antlr4/install.py
+++ b/picireny/antlr4/install.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2016 Renata Hodovan, Akos Kiss.
+#
+# Licensed under the BSD 3-Clause License
+# <LICENSE.md or https://opensource.org/licenses/BSD-3-Clause>.
+# This file may not be copied, modified, or distributed except
+# according to those terms.
+
+import json
+import pkgutil
+import urllib.request
+
+from argparse import ArgumentParser
+from os import makedirs
+from os.path import exists, expanduser, join
+
+from ..cli import __version__
+
+
+def execute():
+    """
+    Entry point of the install helper tool to ease the download of the right
+    version of the ANTLR v4 tool jar.
+    """
+
+    arg_parser = ArgumentParser(description='Install helper tool to download the right version of the ANTLR v4 tool jar.',
+                                prog='picireny-install-antlr4', add_help=True)
+
+    arg_parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))
+
+    mode_group = arg_parser.add_mutually_exclusive_group()
+    mode_group.add_argument('-f', '--force', action='store_true', default=False,
+                            help='Force download even if local antlr4.jar already exists.')
+    mode_group.add_argument('-l', '--lazy', action='store_true', default=False,
+                            help='Don\'t report an error if local antlr4.jar already exists and don\'t try to download it either.')
+
+    args = arg_parser.parse_args()
+
+    local_dir = join(expanduser('~'), '.picireny')
+    tool_path = join(local_dir, 'antlr4.jar')
+
+    if exists(tool_path):
+        if args.lazy:
+            arg_parser.exit()
+        if not args.force:
+            arg_parser.error('Local antlr4.jar already exists: %s' % tool_path)
+
+    tool_url = json.loads(pkgutil.get_data(__package__, join('resources', 'dependencies.json')).decode('ascii'))['tool_url']
+    with urllib.request.urlopen(tool_url) as response:
+        tool_jar = response.read()
+
+    makedirs(local_dir, exist_ok=True)
+
+    with open(tool_path, mode='wb') as tool_file:
+        tool_file.write(tool_jar)

--- a/picireny/antlr4/resources/dependencies.json
+++ b/picireny/antlr4/resources/dependencies.json
@@ -1,0 +1,5 @@
+{
+  "runtime_req": "antlr4-python3-runtime<=4.5.4",
+  "runtime_url": "https://github.com/akosthekiss/antlr4/releases/download/4.5.4-SNAPSHOT%2Bpy3fixes-20160705-1111/antlr4-python3-runtime-4.5.4.tar.gz#egg=antlr4-python3-runtime-4.5.4",
+  "tool_url": "https://github.com/akosthekiss/antlr4/releases/download/4.5.4-SNAPSHOT%2Bpy3fixes-20160705-1111/antlr4-4.5.4-SNAPSHOT.py3fixes-20160705-1111.jar"
+}

--- a/picireny/cli.py
+++ b/picireny/cli.py
@@ -12,8 +12,7 @@ import picire
 import pkgutil
 
 from argparse import ArgumentParser
-from glob import glob
-from os.path import abspath, basename, exists, join, relpath
+from os.path import abspath, basename, exists, expanduser, join, relpath
 from shutil import rmtree
 
 from antlr4 import *
@@ -129,9 +128,9 @@ def execute():
                             help='The grammar file(s) describing the input format.')
     arg_parser.add_argument('-r', '--replacements', help='JSON file defining the default replacements for '
                                                          'any lexer or parser rules.')
-    arg_parser.add_argument('--antlr', default=max(glob(join('/', 'usr', 'local', 'lib', 'antlr-*-complete.jar')), default=None),
-                            help='The path where the antlr jar file is installed'
-                                 '(default: /usr/local/lib/antlr-*-complete.jar).')
+    antlr_default_path = join(expanduser('~'), '.picireny', 'antlr4.jar')
+    arg_parser.add_argument('--antlr', default=antlr_default_path,
+                            help='The path where the antlr jar file is installed (default: %s).' % antlr_default_path)
     arg_parser.add_argument('--islands',
                             help='Python source describing how to process island languages.')
     arg_parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/akosthekiss/antlr4.git@4.5.4-SNAPSHOT+py3fixes-20160705-1111#subdirectory=runtime/Python3&egg=antlr4-python3-runtime

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,19 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
+import json
+
 from os.path import dirname, join
 from setuptools import setup, find_packages
 
 with open(join(dirname(__file__), 'picireny/VERSION'), 'rb') as f:
     version = f.read().decode('ascii').strip()
+
+with open(join(dirname(__file__), 'picireny/antlr4/resources/dependencies.json'), 'r') as f:
+    deps_json = json.load(f)
+    runtime_req = deps_json['runtime_req']
+    runtime_url = deps_json['runtime_url']
+
 
 setup(
     name='picireny',
@@ -21,10 +29,14 @@ setup(
     author_email='hodovan@inf.u-szeged.hu, akiss@inf.u-szeged.hu',
     description='Picireny Hierarchical Delta Debugging Framework',
     long_description=open('README.md').read(),
-    install_requires=['picire', 'antlr4-python3-runtime'],
+    install_requires=['picire', runtime_req],
+    dependency_links=[runtime_url],
     zip_safe=False,
     include_package_data=True,
     entry_points={
-        'console_scripts': ['picireny = picireny.cli:execute']
+        'console_scripts': [
+            'picireny = picireny.cli:execute',
+            'picireny-install-antlr4 = picireny.antlr4.install:execute'
+        ]
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,7 @@ basepython =
     py35: python3.5
 deps =
     pytest
-    -rrequirements.txt
-commands = py.test
+install_command = pip install --process-dependency-links {opts} {packages}
+commands =
+    picireny-install-antlr4 --lazy
+    py.test


### PR DESCRIPTION
- With the help of setuptools dependency_links, the source for the
  correct ANTLR v4 Python 3 runtime snapshot is specified.
- The newly added console script picireny-install-antlr4 downloads
  the correct version of the tool jar and puts it into a new
  default location ($HOME/.picireny/antlr4.jar).
- The picireny CLI looks for the tool jar in the new location by
  default.
