### PR TITLE
Fix HDDTree.tree_str

### DIFF
--- a/picireny/hdd_tree.py
+++ b/picireny/hdd_tree.py
@@ -174,7 +174,7 @@ class HDDTree:
             assert isinstance(node, HDDToken) or None not in node.children, 'Bad parent node: %s' % node.name
         self.traverse(bad_parent)
 
-    def tree_str(self, *, current):
+    def tree_str(self, *, current=None):
         """
         Pretty print HDD tree to help debugging.
 
@@ -194,7 +194,7 @@ class HDDTree:
                                                 node.end.idx)) if self.start is not None and self.end is not None else '',
                 '*' if node == current else '',
                 node.replace,
-                re.sub('^', '    ', ''.join(attrib), flags=re.MULTILINE))
+                ''.join(['    ' + line + '\n' for line in ''.join(attrib).splitlines()]))
 
         return self.synthetic_attribute(_tree_str)
 


### PR DESCRIPTION
Indentation after HDDTokens was wrong making the interpretation of
the resulting string hard. This patch fixes that issue.

Also, add a sensible default value (None) to the current keyword
argument to make invocation easier if we have no concept of current
node.
