### PR TITLE
Don't clear cache if caching is disabled

### DIFF
--- a/picireny/hdd.py
+++ b/picireny/hdd.py
@@ -65,7 +65,8 @@ def hddmin(hdd_tree, reduce_class, reduce_config, tester_class, tester_config, t
                           **reduce_config)
         logger.info('Checking subsets: %s' % str(list(range(count))))
         c = dd.ddmin(list(range(count)))
-        global_structures.outcome_cache.clear()
+        if global_structures.outcome_cache:
+            global_structures.outcome_cache.clear()
 
         hdd_tree.commit_remove(level, c)
         hdd_tree.clear_remove()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,10 @@ resources_dir = os.path.join(tests_dir, 'resources')
 antlr = os.getenv('ANTLR')
 
 
+@pytest.mark.parametrize('args_cache', [
+    (),
+    ('--disable-cache', ),
+])
 class TestCli:
 
     @pytest.mark.parametrize('test,inp,exp,grammar,rule', [
@@ -25,13 +29,14 @@ class TestCli:
         ('test-json-obj-arr-baz.sh', 'inp-obj-arr.json', 'exp-obj-arr-baz.json', 'JSON.g4', 'json'),
         ('test-json-obj-arr-87.sh', 'inp-obj-arr.json', 'exp-obj-arr-87.json', 'JSON.g4', 'json'),
     ])
-    def test_cli(self, test, inp, exp, grammar, rule, tmpdir):
+    def test_cli(self, test, inp, exp, grammar, rule, tmpdir, args_cache):
         out_dir = '%s' % tmpdir
         cmd = (sys.executable, '-m', 'picireny') \
               + ('--test=' + test, '--input=' + inp, '--out=' + out_dir) \
               + ('--grammar=' + grammar, '--start-rule=' + rule)
         if antlr:
               cmd += ('--antlr=' + antlr, )
+        cmd += args_cache
         proc = subprocess.Popen(cmd, cwd=resources_dir)
         proc.communicate()
         assert proc.returncode == 0


### PR DESCRIPTION
We mostly have caching enabled for performance reasons, which makes
disabled cache undertested. This patch fixes an emerged issue (we
tried to clear the cache even if it was disabled) and extends tests
to cover caching to avoid similar issues in the future.
