### PR TITLE
Beautify help message

### DIFF
--- a/picireny/antlr4/install.py
+++ b/picireny/antlr4/install.py
@@ -11,9 +11,9 @@ import urllib.request
 
 from argparse import ArgumentParser
 from os import makedirs
-from os.path import exists, expanduser, join
+from os.path import dirname, exists, join
 
-from ..cli import __version__
+from ..cli import __version__, antlr_default_path
 
 
 def execute():
@@ -22,21 +22,20 @@ def execute():
     version of the ANTLR v4 tool jar.
     """
 
-    arg_parser = ArgumentParser(description='Install helper tool to download the right version of the ANTLR v4 tool jar.',
-                                prog='picireny-install-antlr4', add_help=True)
+    arg_parser = ArgumentParser(description='Install helper tool to download the right version of the ANTLR v4 tool jar.')
 
     arg_parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))
 
     mode_group = arg_parser.add_mutually_exclusive_group()
     mode_group.add_argument('-f', '--force', action='store_true', default=False,
-                            help='Force download even if local antlr4.jar already exists.')
+                            help='force download even if local antlr4.jar already exists')
     mode_group.add_argument('-l', '--lazy', action='store_true', default=False,
-                            help='Don\'t report an error if local antlr4.jar already exists and don\'t try to download it either.')
+                            help='don\'t report an error if local antlr4.jar already exists and don\'t try to download it either')
 
     args = arg_parser.parse_args()
 
-    local_dir = join(expanduser('~'), '.picireny')
-    tool_path = join(local_dir, 'antlr4.jar')
+    tool_path = antlr_default_path
+    local_dir = dirname(tool_path)
 
     if exists(tool_path):
         if args.lazy:

--- a/picireny/cli.py
+++ b/picireny/cli.py
@@ -21,6 +21,7 @@ from .hdd import hddmin
 
 logger = logging.getLogger('picireny')
 __version__ = pkgutil.get_data(__package__, 'VERSION').decode('ascii').strip()
+antlr_default_path = join(expanduser('~'), '.picireny', 'antlr4.jar')
 
 
 def process_args(arg_parser, args):
@@ -118,21 +119,19 @@ def execute():
     """
 
     arg_parser = ArgumentParser(description='CLI for the Picireny Hierarchical Delta Debugging Framework',
-                                prog='Picireny',
                                 parents=[picire.cli.create_parser()], add_help=False)
 
     # Grammar specific settings.
-    arg_parser.add_argument('-s', '--start-rule', required=True,
-                            help='The start rule of the grammar.')
-    arg_parser.add_argument('-g', '--grammar', nargs='+', required=True,
-                            help='The grammar file(s) describing the input format.')
-    arg_parser.add_argument('-r', '--replacements', help='JSON file defining the default replacements for '
-                                                         'any lexer or parser rules.')
-    antlr_default_path = join(expanduser('~'), '.picireny', 'antlr4.jar')
-    arg_parser.add_argument('--antlr', default=antlr_default_path,
-                            help='The path where the antlr jar file is installed (default: %s).' % antlr_default_path)
-    arg_parser.add_argument('--islands',
-                            help='Python source describing how to process island languages.')
+    arg_parser.add_argument('-s', '--start-rule', metavar='NAME', required=True,
+                            help='start rule of the grammar')
+    arg_parser.add_argument('-g', '--grammar', metavar='FILE', nargs='+', required=True,
+                            help='grammar file(s) describing the input format')
+    arg_parser.add_argument('-r', '--replacements', metavar='FILE',
+                            help='JSON file defining the default replacements for lexer or parser rules')
+    arg_parser.add_argument('--antlr', metavar='FILE', default=antlr_default_path,
+                            help='path where the antlr jar file is installed (default: %(default)s)')
+    arg_parser.add_argument('--islands', metavar='FILE',
+                            help='python source describing how to process island languages')
     arg_parser.add_argument('--version', action='version', version='%(prog)s {version}'.format(version=__version__))
 
     args = arg_parser.parse_args()


### PR DESCRIPTION
- No need for explicitly passing `prog` to `ArgParser`, it will
  deduce it automatically.
- Use `metavar` for arguments to make it more intuitive what kind
  of parameters are expected.
- Use `%(choices)s` and `%(default)s` in help strings where
  appropriate.
- Start help descriptions with lower case letters and don't close
  them with full stop to better align with standard help strings
  (e.g., those of `--help` and `--version`).
- Refactor the ANTLR jar default path computation to ease its
  maintenance.
