### PR TITLE
Drop install_command setting from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ basepython =
     py35: python3.5
 deps =
     pytest
-install_command = pip install --process-dependency-links {opts} {packages}
 commands =
     picireny-install-antlr4 --lazy
     py.test


### PR DESCRIPTION
Since Picireny is relying on the official ANTLR 4.6 runtime now,
setup.py is not using dependency_links anymore. Thus, pip installs
the project fine without the --process-dependency-links option, and
therefore, the install_command setting of tox does not have to be
overridden.