### PR TITLE
Example usage fix in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ rule of the top-level parser must be defined with an arbitrary combination of th
 Example usage to reduce an HTML file::
 
     picireny --input=<path/to/the/input.html> --test=<path/to/the/tester> \
-             --grammar "HTMLLexer.g4 HTMLParser.g4" --start htmlDocument \
+             --grammar HTMLLexer.g4 HTMLParser.g4 --start htmlDocument \
              --parallel --subset-iterator=skip --complement-iterator=backward
 
 


### PR DESCRIPTION
Otherwise picireny complains about "cannot find the file" since it views the white space as part of the file path.