### PR TITLE
Drop support of Python3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,7 @@ disable=
     useless-object-inheritance, unnecessary-pass, duplicate-code,
     attribute-defined-outside-init, import-outside-toplevel, abstract-method,
     consider-using-with, unused-private-member, deprecated-module,
-    unspecified-encoding, consider-using-f-string
+    unspecified-encoding
 
 [REPORTS]
 

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ still "interesting" output.
 Requirements
 ============
 
-* Python_ >= 3.5
+* Python_ >= 3.6
 * Java_ SE >= 7 JRE or JDK (the latter is optional, only needed if Java is used
   as the parser language)
 

--- a/picireny/antlr4/hdd_tree_builder.py
+++ b/picireny/antlr4/hdd_tree_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -123,7 +123,7 @@ def create_hdd_tree(src, *,
 
     def compile_java_sources(lexer, parser, listener, current_workdir):
         executor = Template(get_data(__package__, 'resources/ExtendedTargetParser.java').decode('utf-8'))
-        with open(join(current_workdir, 'Extended{parser}.java'.format(parser=parser)), 'w') as f:
+        with open(join(current_workdir, f'Extended{parser}.java'), 'w') as f:
             f.write(executor.substitute(dict(lexer_class=lexer,
                                              parser_class=parser,
                                              listener_class=listener)))
@@ -276,7 +276,7 @@ def create_hdd_tree(src, *,
                     self.exit_optional()
 
                 assert self.current_node.name == self.parser.ruleNames[ctx.getRuleIndex()], \
-                    '%s (%s) != %s' % (self.current_node.name, repr(self.current_node), self.parser.ruleNames[ctx.getRuleIndex()])
+                    f'{self.current_node.name} ({self.current_node!r}) != {self.parser.ruleNames[ctx.getRuleIndex()]}'
 
                 if self.current_node.parent:
                     self.current_node = self.current_node.parent
@@ -394,7 +394,7 @@ def create_hdd_tree(src, *,
 
             try:
                 current_workdir = join(work_dir, grammar_name) if grammar_name else work_dir
-                proc = run(('java', '-classpath', java_classpath(current_workdir), 'Extended{parser}'.format(parser=grammar['parser']), start_rule),
+                proc = run(('java', '-classpath', java_classpath(current_workdir), f'Extended{grammar["parser"]}', start_rule),
                            input=src, stdout=PIPE, stderr=PIPE, universal_newlines=True, cwd=current_workdir, check=True)
                 if proc.stderr:
                     logger.debug(proc.stderr)

--- a/picireny/antlr4/parser_builder.py
+++ b/picireny/antlr4/parser_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -58,10 +58,10 @@ def build_grammars(grammars, out, antlr, lang='python'):
             return f
 
         # Extract the name of lexer and parser from their path.
-        lexer = file_endswith('Lexer.{ext}'.format(ext=languages[lang]['ext']))
-        parser = file_endswith('Parser.{ext}'.format(ext=languages[lang]['ext']))
+        lexer = file_endswith(f'Lexer.{languages[lang]["ext"]}')
+        parser = file_endswith(f'Parser.{languages[lang]["ext"]}')
         # The name of the generated listeners differs if Python or other language target is used.
-        listener = file_endswith('{listener_format}.{ext}'.format(listener_format=languages[lang]['listener_format'], ext=languages[lang]['ext']))
+        listener = file_endswith(f'{languages[lang]["listener_format"]}.{languages[lang]["ext"]}')
 
         if lang == 'python':
             grammar_cache[lang][grammars] = [getattr(__import__(x, globals(), locals(), [x], 0), x) for x in [lexer, parser, listener]]

--- a/picireny/cli.py
+++ b/picireny/cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -53,7 +53,7 @@ def process_antlr4_args(args):
             for i, fn in enumerate(data['files']):
                 path = join(abspath(dirname(args.format)), fn)
                 if not exists(path):
-                    raise ValueError('Invalid input format definition: %s, defined in the format config, does not exist.' % path)
+                    raise ValueError(f'Invalid input format definition: {path}, defined in the format config, does not exist.')
                 data['files'][i] = path
             data['islands'] = data.get('islands', {})
             data['replacements'] = data.get('replacements', {})
@@ -63,7 +63,7 @@ def process_antlr4_args(args):
 
     if args.format:
         if not exists(args.format):
-            raise ValueError('Invalid input format definition: %s does not exist.' % args.format)
+            raise ValueError(f'Invalid input format definition: {args.format} does not exist.')
 
         with open(args.format, 'r') as f:
             try:
@@ -72,7 +72,7 @@ def process_antlr4_args(args):
                 if not args.start:
                     args.start = input_description.get('start', None)
             except ValueError as e:
-                raise ValueError('Invalid input format definition: The content of %s is not a valid JSON object.' % args.format) from e
+                raise ValueError(f'Invalid input format definition: The content of {args.format} is not a valid JSON object.') from e
 
     if not args.start:
         raise ValueError('Invalid input format definition: No start has been defined.')
@@ -86,17 +86,17 @@ def process_antlr4_args(args):
             for i, g in enumerate(args.grammar):
                 args.input_format['']['files'].append(realpath(g))
                 if not exists(args.input_format['']['files'][i]):
-                    raise ValueError('Invalid input format definition: %s does not exist.' % args.input_format['']['files'][i])
+                    raise ValueError(f'Invalid input format definition: {args.input_format[""]["files"][i]} does not exist.')
 
         if args.replacements:
             if not exists(args.replacements):
-                raise ValueError('Invalid input format definition: %s does not exist.' % args.replacements)
+                raise ValueError(f'Invalid input format definition: {args.replacements} does not exist.')
 
             try:
                 with open(args.replacements, 'r') as f:
                     args.input_format['']['replacements'] = json.load(f)
             except ValueError as e:
-                raise ValueError('Invalid input format definition: The content of %s is not a valid JSON object.' % args.replacements) from e
+                raise ValueError(f'Invalid input format definition: The content of {args.replacements} is not a valid JSON object.') from e
 
 
 def process_srcml_args(args):
@@ -123,8 +123,8 @@ def log_tree(title, hdd_tree):
     logger.debug('%s\n\theight: %s\n\tshape: %s\n\tnodes: %s\n',
                  title,
                  info.height(hdd_tree),
-                 ', '.join('%s' % cnt for cnt in info.shape(hdd_tree)),
-                 ', '.join('%d %s' % (cnt, ty) for ty, cnt in sorted(info.count(hdd_tree).items())))
+                 ', '.join(str(cnt) for cnt in info.shape(hdd_tree)),
+                 ', '.join(f'{cnt} {ty}' for ty, cnt in sorted(info.count(hdd_tree).items())))
     logger.trace('%r', hdd_tree)
 
 
@@ -244,12 +244,12 @@ def reduce(hdd_tree, *,
         hdd_tree = hddmin(hdd_tree,
                           reduce_class=reduce_class, reduce_config=reduce_config,
                           tester_class=tester_class, tester_config=tester_config,
-                          id_prefix=('p%d' % phase_cnt,),
+                          id_prefix=(f'p{phase_cnt}',),
                           cache=cache_class() if cache_class else None,
                           unparse_with_whitespace=unparse_with_whitespace,
                           hdd_star=hdd_star,
                           **phase_config)
-        log_tree('Tree after reduction phase #%d' % phase_cnt, hdd_tree)
+        log_tree(f'Tree after reduction phase #{phase_cnt}', hdd_tree)
 
     return hdd_tree
 

--- a/picireny/hdd.py
+++ b/picireny/hdd.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2007 Ghassan Misherghi.
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 # Copyright (c) 2021 Daniel Vince
 #
 # Licensed under the BSD 3-Clause License
@@ -79,7 +79,7 @@ def hddmin(hdd_tree, *,
                 hdd_tree, transformed = transformation(hdd_tree, level_nodes,
                                                        reduce_class=reduce_class, reduce_config=reduce_config,
                                                        tester_class=tester_class, tester_config=tester_config,
-                                                       id_prefix=id_prefix + ('i%d' % iter_cnt, 'l%d' % level, 't%d' % trans_cnt),
+                                                       id_prefix=id_prefix + (f'i{iter_cnt}', f'l{level}', f't{trans_cnt}'),
                                                        cache=cache,
                                                        unparse_with_whitespace=unparse_with_whitespace)
 

--- a/picireny/hdd_tree.py
+++ b/picireny/hdd_tree.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2007 Ghassan Misherghi.
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -48,7 +48,7 @@ class Position(object):
             self.column += start.column
 
     def __repr__(self):
-        return '%s(%r, %r)' % (self.__class__.__name__, self.line, self.column)
+        return f'{self.__class__.__name__}({self.line!r}, {self.column!r})'
 
 
 class HDDTree(object):
@@ -135,20 +135,20 @@ class HDDToken(HDDTree):
 
     def __repr__(self):
         parts = [
-            'name=%r' % self.name,
-            'text=%r' % self.text,
+            f'name={self.name!r}',
+            f'text={self.text!r}',
         ]
         if self.replace is not None:
-            parts.append('replace=%r' % self.replace)
+            parts.append(f'replace={self.replace!r}')
         if self.start is not None:
-            parts.append('start=%r' % self.start)
+            parts.append(f'start={self.start!r}')
         if self.end is not None:
-            parts.append('end=%r' % self.end)
-        parts.append('id=%r' % self.id)
+            parts.append(f'end={self.end!r}')
+        parts.append(f'id={self.id!r}')
         if self.state != self.KEEP:
-            parts.append('state=%r' % self.state)
+            parts.append(f'state={self.state!r}')
 
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(parts))
+        return f'{self.__class__.__name__}({", ".join(parts)})'
 
 
 class HDDRule(HDDTree):
@@ -172,18 +172,18 @@ class HDDRule(HDDTree):
             return ''.join(prefix + line for line in text.splitlines(True))
 
         parts = [
-            'name=%r' % self.name,
+            f'name={self.name!r}',
         ]
         if self.replace is not None:
-            parts.append('replace=%r' % self.replace)
+            parts.append(f'replace={self.replace!r}')
         if self.start is not None:
-            parts.append('start=%r' % self.start)
+            parts.append(f'start={self.start!r}')
         if self.end is not None:
-            parts.append('end=%r' % self.end)
-        parts.append('id=%r' % self.id)
+            parts.append(f'end={self.end!r}')
+        parts.append(f'id={self.id!r}')
         if self.state != self.KEEP:
-            parts.append('state=%r' % self.state)
+            parts.append(f'state={self.state!r}')
         if self.state == self.KEEP and self.children:
             parts.append('children=[\n%s\n]' % _indent(',\n'.join(repr(child) for child in self.children), '  '))
 
-        return '%s(%s)' % (self.__class__.__name__, ', '.join(parts))
+        return f'{self.__class__.__name__}({", ".join(parts)})'

--- a/picireny/hddr.py
+++ b/picireny/hddr.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
 # Copyright (c) 2021 Daniel Vince
 #
 # Licensed under the BSD 3-Clause License
@@ -91,7 +91,7 @@ def hddrmin(hdd_tree, *,
                     hdd_tree, transformed = transformation(hdd_tree, children,
                                                            reduce_class=reduce_class, reduce_config=reduce_config,
                                                            tester_class=tester_class, tester_config=tester_config,
-                                                           id_prefix=id_prefix + ('i%d' % iter_cnt, 'n%d' % node_cnt, 't%d' % trans_cnt),
+                                                           id_prefix=id_prefix + (f'i{iter_cnt}', f'n{node_cnt}', f't{trans_cnt}'),
                                                            cache=cache,
                                                            unparse_with_whitespace=unparse_with_whitespace)
 

--- a/picireny/hoist.py
+++ b/picireny/hoist.py
@@ -86,7 +86,7 @@ class MappingMin(AbstractDD):
                 new_mapping = mapping.copy()
                 new_mapping[c] = m
                 mapping_config = list(new_mapping.items())
-                config_id = ('r%d' % run, 'm%d' % i)
+                config_id = (f'r{run}', f'm{i}')
 
                 outcome = self._lookup_cache(mapping_config, config_id) or self._test_config(mapping_config, config_id)
 

--- a/picireny/srcml/hdd_tree_builder.py
+++ b/picireny/srcml/hdd_tree_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2018-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -28,7 +28,7 @@ def build_hdd_tree(element, start):
 
     if element.text:
         end = start.after(element.text)
-        rule.add_child(HDDToken('{name}@text'.format(name=name), element.text, start=start, end=end, replace=element.text))
+        rule.add_child(HDDToken(f'{name}@text', element.text, start=start, end=end, replace=element.text))
         rule.end = end
 
     for child in list(element):
@@ -39,7 +39,7 @@ def build_hdd_tree(element, start):
             rule.end = rule.children[-1].end
 
     if element.tail:
-        result += [HDDToken('{name}@tail'.format(name=name), element.tail, start=rule.end, end=rule.end.after(element.tail), replace=element.tail)]
+        result += [HDDToken(f'{name}@tail', element.tail, start=rule.end, end=rule.end.after(element.tail), replace=element.tail)]
 
     return result
 
@@ -54,7 +54,7 @@ def create_hdd_tree(src, *, language):
     """
 
     try:
-        stdout = run(('srcml', '--language={language}'.format(language=language)),
+        stdout = run(('srcml', f'--language={language}'),
                      input=src, stdout=PIPE, stderr=PIPE, check=True).stdout
     except CalledProcessError as e:
         logger.error('Parsing with srcml failed!\n%s\n%s\n', e.stdout, e.stderr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,18 +14,19 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Testing
 platform = any
 
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.5
+python_requires = >=3.6
 install_requires =
     antlerinator>=1!1.0.0
     antlr4-python3-runtime==4.9.2

--- a/tests/resources/sut-json-load.py
+++ b/tests/resources/sut-json-load.py
@@ -7,4 +7,4 @@ import sys
 with open(sys.argv[1], 'r') as f:
     j = json.load(f)
 
-print("%s" % repr(j))
+print(repr(j))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -40,16 +40,16 @@ antlr = os.getenv('ANTLR')
 def test_cli(test, inp, exp, grammar, rule, input_format, args, tmpdir):
     out_dir = str(tmpdir)
     cmd = (sys.executable, '-m', 'picireny') \
-          + ('--test=' + test + script_ext, '--input=' + inp, '--out=' + out_dir) \
+          + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
           + ('--log-level=TRACE', )
     if grammar:
-        cmd += ('--grammar=' + grammar, )
+        cmd += (f'--grammar={grammar}', )
     if rule:
-        cmd += ('--start=' + rule, )
+        cmd += (f'--start={rule}', )
     if input_format:
-        cmd += ('--format=' + input_format, )
+        cmd += (f'--format={input_format}', )
     if antlr:
-        cmd += ('--antlr=' + antlr, )
+        cmd += (f'--antlr={antlr}', )
     cmd += args
     subprocess.run(cmd, cwd=resources_dir, check=True)
 


### PR DESCRIPTION
Python3.5 has reached the end of its lifetime two years ago, hence Picireny also stops supporting it. The patch introduces the usage of f-strings - supported from Python3.6 - and unifies string representations to use it where possible.
It also enables the 'consider-using-f-string' pylint checker.