### PR TITLE
ANTLeRinator 1!3.0.0 doesn't clean generated files before sdist

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,6 +15,7 @@ ignore=parser
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    useless-option-value,
     line-too-long, fixme, missing-docstring, invalid-name, no-self-use, unused-argument,
     wildcard-import, unused-wildcard-import, ungrouped-imports,
     too-many-arguments, too-many-locals,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+exclude picireny/antlr4/parser/ANTLRv4*.py

--- a/picireny/antlr4/hdd_tree_builder.py
+++ b/picireny/antlr4/hdd_tree_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -124,9 +124,9 @@ def create_hdd_tree(src, *,
     def compile_java_sources(lexer, parser, listener, current_workdir):
         executor = Template(get_data(__package__, 'resources/ExtendedTargetParser.java').decode('utf-8'))
         with open(join(current_workdir, f'Extended{parser}.java'), 'w') as f:
-            f.write(executor.substitute(dict(lexer_class=lexer,
-                                             parser_class=parser,
-                                             listener_class=listener)))
+            f.write(executor.substitute({'lexer_class': lexer,
+                                         'parser_class': parser,
+                                         'listener_class': listener}))
         try:
             run(('javac', '-classpath', java_classpath(current_workdir)) + tuple(basename(j) for j in glob(join(current_workdir, '*.java'))),
                 stdout=PIPE, stderr=STDOUT, cwd=current_workdir, check=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "antlerinator>=1!1.1.0",
+    "antlerinator>=1!3.0.0",
     "setuptools",
     "setuptools_scm[toml]",
     "wheel",

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    antlerinator>=1!1.0.0
+    antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.9.2
     importlib-metadata; python_version < "3.8"
     inators

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     pylint
 commands =
     pylint picireny
-    pycodestyle picireny --ignore=E501
+    pycodestyle picireny --ignore=E501 --exclude=picireny/antlr4/parser/ANTLRv4*.py
 
 [testenv:build]
 deps =


### PR DESCRIPTION
This helps running tox when working with a development mode
install, but requires adding a manifest template.

Also fix pylint issues
- `no-self-use` warning had to be disabled previously for pylint.
  But recent pylint does not check for it anymore, and so listing
  it as disabled causes a warning. As both older and newer pylint
  versions are to be supported, the new warning is also disabled.
- Adapted the code to fix `use-dict-literal` pylint errors.
