### PR TITLE
Drop support of Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,13 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
-        exclude:
-          - python-version: 3.6
-            os: ubuntu-latest
-        include:
-          - python-version: 3.6
-            os: ubuntu-20.04
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', 'pypy-3.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ still "interesting" output.
 Requirements
 ============
 
-* Python_ >= 3.6
+* Python_ >= 3.7
 * Java_ SE >= 7 JRE or JDK (the latter is optional, only needed if Java is used
   as the parser language)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ platform = any
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.9.2


### PR DESCRIPTION
Python 3.6 has reached the end of its lifetime more than a year ago.