### PR TITLE
Update ANTLR4 grammar to the latest official master

### DIFF
--- a/picireny/antlr4/grammar_analyzer.py
+++ b/picireny/antlr4/grammar_analyzer.py
@@ -132,8 +132,8 @@ def analyze_grammars(grammars, replacements):
         if isinstance(ctx, parser.LexerElementsContext):
             return ANTLRLexerElements()
 
-        # LabeledLexerElement and LexerBlock are created since they can have quantifier.
-        if isinstance(ctx, (parser.LabeledLexerElementContext, parser.LexerBlockContext)):
+        # LexerBlock is created since it can have quantifier.
+        if isinstance(ctx, parser.LexerBlockContext):
             return ANTLRLexerElement(optional=optional)
 
         # LexerAtom can also have quantifier. Furthermore it may have terminal children

--- a/picireny/antlr4/resources/ANTLRv4Parser.g4
+++ b/picireny/antlr4/resources/ANTLRv4Parser.g4
@@ -212,7 +212,7 @@ labeledAlt
    // Lexer rules
 
 lexerRuleSpec
-   : FRAGMENT? TOKEN_REF COLON lexerRuleBlock SEMI
+   : FRAGMENT? TOKEN_REF optionsSpec? COLON lexerRuleBlock SEMI
    ;
 
 lexerRuleBlock
@@ -235,16 +235,11 @@ lexerElements
    ;
 
 lexerElement
-   : labeledLexerElement ebnfSuffix?
-   | lexerAtom ebnfSuffix?
+   : lexerAtom ebnfSuffix?
    | lexerBlock ebnfSuffix?
    | actionBlock QUESTION?
    ;
    // but preds can be anywhere
-
-labeledLexerElement
-   : identifier (ASSIGN | PLUS_ASSIGN) (lexerAtom | lexerBlock)
-   ;
 
 lexerBlock
    : LPAREN lexerAltList RPAREN


### PR DESCRIPTION
Since ANTLRv4 does not support element labels in lexer rules, the official grammar has been updated (see antlr/grammars-v4#3205). Consequently, the ANTLR4 grammar in Picireny has also been updated, as well as the grammar analysis logic.