### PR TITLE
Use JSONx to transfer parse tree between processes

### DIFF
--- a/picireny/antlr4/hdd_tree_builder.py
+++ b/picireny/antlr4/hdd_tree_builder.py
@@ -5,7 +5,6 @@
 # This file may not be copied, modified, or distributed except
 # according to those terms.
 
-import json
 import logging
 import re
 import shutil
@@ -17,6 +16,8 @@ from os.path import basename, join
 from pkgutil import get_data
 from string import Template
 from subprocess import CalledProcessError, PIPE, run, STDOUT
+
+import xson
 
 from antlr4 import CommonTokenStream, error, InputStream, Token
 from antlr4.Token import CommonToken
@@ -372,7 +373,7 @@ def create_hdd_tree(src, *,
         logger.debug('Parse input with %s rule', start_rule)
         if lang != 'python':
 
-            def hdd_tree_from_json(node_dict):
+            def hdd_tree_from_dict(node_dict):
                 # Convert interval dictionaries to Position objects.
                 if 'start' in node_dict:
                     node_dict['start'] = Position(**node_dict['start'])
@@ -386,7 +387,7 @@ def create_hdd_tree(src, *,
 
                 if children:
                     for child in children:
-                        node.add_child(hdd_tree_from_json(child))
+                        node.add_child(hdd_tree_from_dict(child))
                 elif name:
                     if name in grammar['islands']:
                         island_nodes.append(node)
@@ -398,8 +399,8 @@ def create_hdd_tree(src, *,
                            input=src, stdout=PIPE, stderr=PIPE, universal_newlines=True, cwd=current_workdir, check=True)
                 if proc.stderr:
                     logger.debug(proc.stderr)
-                result = json.loads(proc.stdout)
-                tree_root = hdd_tree_from_json(result)
+                result = xson.loads(proc.stdout)
+                tree_root = hdd_tree_from_dict(result)
             except CalledProcessError as e:
                 logger.error('Java parser failed!\n%s\n%s', e.stdout, e.stderr)
                 raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     importlib-metadata; python_version < "3.8"
     inators
     picire==21.8
+    xson
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
By default, the language of the parsers generated from grammars is Python and they are executed in-process. However, the generation of Java parsers is also supported for performance reasons, in which case the parsers are executed in a separate process and their result must be communicated back to the Python part of the reducer.

The data exchange format used to be JSON, but JSON is not a first-class citizen in Java and standard edition contains no packages to read/write JSON. Unfortunately, the latest releases of ANTLR have stopped bundling a JSON implementation with the tool jar.

To avoid the need for adding dependencies to the use of Java parsers, the data exchange format is changed to JSONx. Serialization to JSONx in Java is supportd by a minimal partial implementation, while deserialization in Python is supported by the XSON project.