### PR TITLE
Pylint-induced maintenance

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -30,10 +30,8 @@ disable=
     too-many-locals,
     too-many-return-statements,
     too-many-statements,
-    unnecessary-pass,
     unspecified-encoding,
     unused-argument,
-    useless-object-inheritance,
     useless-option-value,  # disables warning in recent pylint that does not check for no-self-use anymore
 
 [REPORTS]

--- a/picireny/antlr4/antlr_tree.py
+++ b/picireny/antlr4/antlr_tree.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 # Parser Elements
 
-class ANTLRElement(object):
+class ANTLRElement:
     def __init__(self, *, optional=False, repl=None, sep=''):
         """
         Constructor of the base tree node type.

--- a/picireny/antlr4/hdd_tree_builder.py
+++ b/picireny/antlr4/hdd_tree_builder.py
@@ -43,7 +43,6 @@ class HDDHiddenToken(HDDToken):
     """
     Special token type that represents tokens from hidden channels.
     """
-    pass
 
 
 class HDDErrorToken(HDDToken):

--- a/picireny/hdd_tree.py
+++ b/picireny/hdd_tree.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2007 Ghassan Misherghi.
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -10,7 +10,7 @@ from itertools import count
 from os import linesep
 
 
-class Position(object):
+class Position:
     """
     Class defining a position in the input file. Used to recognise line breaks
     between tokens.
@@ -51,7 +51,7 @@ class Position(object):
         return f'{self.__class__.__name__}({self.line!r}, {self.column!r})'
 
 
-class HDDTree(object):
+class HDDTree:
     # Node states for unparsing.
     REMOVED = 0
     KEEP = 1

--- a/picireny/hoist.py
+++ b/picireny/hoist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 # Copyright (c) 2021 Daniel Vince.
 #
 # Licensed under the BSD 3-Clause License
@@ -14,7 +14,7 @@ from picire import AbstractDD, Outcome
 logger = logging.getLogger(__name__)
 
 
-class HoistingTestBuilder(object):
+class HoistingTestBuilder:
 
     def __init__(self, tree, *, with_whitespace=True):
         """

--- a/picireny/prune.py
+++ b/picireny/prune.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2021-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -14,7 +14,7 @@ from picire import AbstractDD, Outcome
 logger = logging.getLogger(__name__)
 
 
-class PruningTestBuilder(object):
+class PruningTestBuilder:
 
     def __init__(self, tree, ids, *, with_whitespace=True):
         """


### PR DESCRIPTION
- Remove the explicit `object` superclass definition from classes. In Python3, object is the implicit superclass. There is no need to explicitly define it.
- Remove unnecessary pass.