### PR TITLE
Ensure test quality via linting

### DIFF
--- a/tests/resources/sut-json-load.py
+++ b/tests/resources/sut-json-load.py
@@ -4,7 +4,7 @@ import json
 import sys
 
 
-with open(sys.argv[1], 'r') as f:
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
     j = json.load(f)
 
-print(repr(j))
+print(f'{j!r}')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Renata Hodovan, Akos Kiss.
+# Copyright (c) 2016-2023 Renata Hodovan, Akos Kiss.
 #
 # Licensed under the BSD 3-Clause License
 # <LICENSE.rst or https://opensource.org/licenses/BSD-3-Clause>.
@@ -6,9 +6,10 @@
 # according to those terms.
 
 import os
-import pytest
 import subprocess
 import sys
+
+import pytest
 
 
 is_windows = sys.platform.startswith('win32')
@@ -40,8 +41,8 @@ antlr = os.getenv('ANTLR')
 def test_cli(test, inp, exp, grammar, rule, input_format, args, tmpdir):
     out_dir = str(tmpdir)
     cmd = (sys.executable, '-m', 'picireny') \
-          + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
-          + ('--log-level=TRACE', )
+        + (f'--test={test}{script_ext}', f'--input={inp}', f'--out={out_dir}') \
+        + ('--log-level=TRACE', )
     if grammar:
         cmd += (f'--grammar={grammar}', )
     if rule:

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,10 @@ omit = **/parser/*
 deps =
     pycodestyle
     pylint
+    pytest
 commands =
-    pylint picireny
-    pycodestyle picireny --ignore=E501 --exclude=picireny/antlr4/parser/ANTLRv4*.py
+    pylint picireny tests
+    pycodestyle picireny tests --ignore=E501 --exclude=picireny/antlr4/parser/ANTLRv4*.py
 
 [testenv:build]
 deps =


### PR DESCRIPTION
- Start specifying encoding when opening a file
- Use f-strings
- List standard modules first in imports.
- Avoid visual indenting