### PR TITLE
Bump meta-schema version of input format schema to draft 2020-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,18 @@ jobs:
       - run: pip install --upgrade tox
       - run: tox -v -e lint
 
+  schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install --upgrade tox
+      - run: tox -v -e schema
+
   cov:
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    needs: [test, lint]
+    needs: [test, lint, schema]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/schemas/format.json
+++ b/schemas/format.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
 
     "description": "Picireny input format definition.",
     "type": "object",

--- a/schemas/replacements.json
+++ b/schemas/replacements.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
 
     "description": "Replacement strings mapped to grammar token names.",
     "type": "object",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py, lint, build
+envlist = py, lint, schema, build
 isolated_build = true
 
 [testenv]
@@ -24,6 +24,14 @@ deps =
 commands =
     pylint picireny tests
     pycodestyle picireny tests --ignore=E501 --exclude=picireny/antlr4/parser/ANTLRv4*.py
+
+[testenv:schema]
+deps =
+    check-jsonschema
+skip_install = true
+commands =
+    check-jsonschema -v --check-metaschema schemas/format.json schemas/replacements.json
+    check-jsonschema -v --schemafile schemas/format.json tests/resources/inijson.json tests/resources/inijson-crlf.json
 
 [testenv:build]
 deps =


### PR DESCRIPTION
Also add a tox environment to check the input format schema files (in schemas/) and the input format instance files (in tests/resources/).