### PR TITLE
Python recognizes package data directories as importable packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ platform = any
 [options]
 package_dir =
     = src
-packages = find:
+packages = find_namespace:
 include_package_data = True
 python_requires = >=3.8
 install_requires =


### PR DESCRIPTION
However, as they are absent from setuptools' `packages` configuration, this causes warnings that they would be ignored. The recommended approach is to treat data as namespace package using the `find_namespace:` discovery mechanism.

The affected data directory / package:
- picireny.antlr4.resources