### PR TITLE
Rename tox environment schema to jsonschema

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - run: pip install --upgrade tox
       - run: tox -v -e lint
 
-  schema:
+  jsonschema:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip install --upgrade tox
-      - run: tox -v -e schema
+      - run: tox -v -e jsonschema
 
   cov:
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
-    needs: [test, lint, schema]
+    needs: [test, lint, jsonschema]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2024 Renata Hodovan, Akos Kiss.
+Copyright (c) 2016-2025 Renata Hodovan, Akos Kiss.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py, lint, schema, build
+envlist = py, lint, jsonschema, build
 isolated_build = true
 
 [testenv]
@@ -25,7 +25,7 @@ commands =
     pylint src/picireny tests
     pycodestyle src/picireny tests --ignore=E501 --exclude=src/picireny/antlr4/parser/ANTLRv4*.py
 
-[testenv:schema]
+[testenv:jsonschema]
 deps =
     check-jsonschema
 skip_install = true


### PR DESCRIPTION
Tox introduced a new command `schema` in 4.24.0, which conflicts with the same environment name we used in `tox.ini`.

This happens because we call tox as `tox -e ENV`, relying on `run` being the default command for tox. So, `tox run -e schema` would also be an option, but that would require a lot of changes (if we were to apply the change everywhere consistently). Thus, it is easier to rename the environment instead.

Also: Update years in license