### PR TITLE
Enable subprocess patch for coverage measurement

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ usedevelop = true
 
 [coverage:run]
 omit = **/parser/*
+patch = subprocess
+disable_warnings = module-not-imported  # NOTE: since all test are CLI tests, picireny is only imported from subprocesses, causing misleading diagnostics
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
From pytest-cov 7.0.0 (released on 2025-09-09), the support for subprocess measurement has been dropped. This has caused drastic loss of information (to the point that absolutely no coverage data was collected and reported). The patch system of the underlying coverage package (since 7.10) has a way to measure subprocesses created in tests, but it needs to be enabled explicitly.