### PR TITLE
Update Python support: drop 3.9, add 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10', '3.11', '3.12', '3.13', 'pypy-3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.11']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ still "interesting" output.
 Requirements
 ============
 
-* Python_ >= 3.9
+* Python_ >= 3.10
 * Java_ SE >= 11 JRE or JDK (the latter is optional, only needed if Java is used
   as the parser language)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Testing
 platform = any
 
@@ -26,7 +26,7 @@ package_dir =
     = src
 packages = find_namespace:
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     antlerinator>=1!3.0.0
     antlr4-python3-runtime==4.13.2


### PR DESCRIPTION
Python 3.14 has been released, while 3.9 reached its end of life.